### PR TITLE
Add boolean modifiers to InlineStylesheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ stylesheet.styles({ theme: 'ghost', color: 'green' });
 ```
 
 ### Boolean modifiers
-Some modifiers exist as booleans only. Depending on whether the value of the said modifier is set to 'true' or not, the styles will be applied accordingly.
+In some cases you'd like to define modifiers as a simple boolean value. `InlineStylesheet` also covers that:
 
 ```js
 const stylesheet = InlineStylesheet.create(`
@@ -236,6 +236,7 @@ const stylesheet = InlineStylesheet.create(`
 `, {
   disabled:`
     background: grey;
+    border-color: grey;
   `,
 });
 
@@ -244,6 +245,7 @@ const stylesheet = InlineStylesheet.create(`
     fontSize: '12px';
     border: '1px solid';
     background: 'grey';
+    border-color: 'grey';
 }
  */
 stylesheet.styles({ disabled: true });

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ stylesheet.concat({
 ## Advanced usage
 
 ### Modifiers with dependencies
-Sometimes modifiers to depend on each other. Image a button that needs to apply colors differently depending on the given theme. Therefore you can use the feature of nested modifier style declaration.
+Sometimes modifiers depend on each other. Image a button that needs to apply colors differently depending on the given theme. Therefore you can use the feature of nested modifier style declaration.
 
 ```js
 const stylesheet = InlineStylesheet.create(`
@@ -224,6 +224,29 @@ const stylesheet = InlineStylesheet.create(`
 }
  */
 stylesheet.styles({ theme: 'ghost', color: 'green' });
+```
+
+### Boolean modifiers
+Some modifiers exist as booleans only. Depending on whether the value of the said modifier is set to 'true' or not, the styles will be applied accordingly.
+
+```js
+const stylesheet = InlineStylesheet.create(`
+  font-size: 12px;
+  border: 1px solid;
+`, {
+  disabled:`
+    background: grey;
+  `,
+});
+
+/*
+  {
+    fontSize: '12px';
+    border: '1px solid';
+    background: 'grey';
+}
+ */
+stylesheet.styles({ disabled: true });
 ```
 
 ### Define styles using string templates

--- a/src/InlineStylesheet.js
+++ b/src/InlineStylesheet.js
@@ -96,7 +96,7 @@ class InlineStylesheet {
       );
     }
 
-    const resolvedStyle = styles[key][props[key]];
+    const resolvedStyle = typeof styles[key] === 'string' ? styles[key] : styles[key][props[key]];
 
     if (this._isEntrypoint(resolvedStyle)) {
       return this._resolveStyle(

--- a/src/InlineStylesheet.test.js
+++ b/src/InlineStylesheet.test.js
@@ -70,7 +70,7 @@ test('support concatination after creation', () => {
   };
   expect(actual).toEqual(expected);
 });
-
+//
 describe('resolves styles', () => {
   const styles = InlineStylesheet
     .create(`
@@ -105,8 +105,11 @@ describe('resolves styles', () => {
         status: {
           disabled: 'color: white; background: grey;',
         },
+        disabled: `
+          background: grey;
+        `,
       });
-
+  //
   test('when no modifiers are given', () => {
     const expected = {
       fontSize: '12px',
@@ -122,6 +125,15 @@ describe('resolves styles', () => {
       background: 'red',
     };
     const actual = styles.styles({ size: 'l' });
+    expect(actual).toEqual(expected);
+  });
+
+  test('when boolean modifiers are given', () => {
+    const expected = {
+      fontSize: '12px',
+      background: 'grey',
+    };
+    const actual = styles.styles({ disabled: true });
     expect(actual).toEqual(expected);
   });
 

--- a/src/InlineStylesheet.test.js
+++ b/src/InlineStylesheet.test.js
@@ -70,7 +70,7 @@ test('support concatination after creation', () => {
   };
   expect(actual).toEqual(expected);
 });
-//
+
 describe('resolves styles', () => {
   const styles = InlineStylesheet
     .create(`
@@ -109,7 +109,7 @@ describe('resolves styles', () => {
           background: grey;
         `,
       });
-  //
+
   test('when no modifiers are given', () => {
     const expected = {
       fontSize: '12px',


### PR DESCRIPTION
Sometimes we want modifiers as booleans. To accomodate that need resolvedStyle was reworked a bit and it now accepts boolean values and, depending on whether the value of the modifier is a boolean or not, applies the styles accordingly.
